### PR TITLE
feat: implement Google OAuth authentication (#38)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,10 +31,10 @@ jobs:
         env:
           WAIT_FOR_VERSION: 4df3f9262d84cab0039c07bf861045fbb3c20ab7 # v2.2.3
 
-      - name: 'Install Node.js v.14'
+      - name: 'Install Node.js v.18'
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
 
       - name: 'Install dependencies'
         run: npm install

--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,11 @@ test-report.xml
 .env.development.local
 .env.test.local
 .env.production.local
-.idea
 
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+#IDE
+.idea
+.vscode

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "dotenv": "^10.0.0",
         "email-templates": "^10.0.0",
         "express": "^4.17.1",
+        "express-rate-limit": "^8.1.0",
         "google-auth-library": "^10.3.0",
         "googleapis": "^105.0.0",
         "jsonwebtoken": "^8.5.1",
@@ -4687,6 +4688,23 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.1.0.tgz",
+      "integrity": "sha512-4nLnATuKupnmwqiJc27b4dCFmB/T60ExgmtDD7waf4LdrbJ8CPZzZRHYErDYNhoz+ql8fUdYwM/opf90PoPAQA==",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/cookie": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
@@ -5936,6 +5954,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
       "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "dotenv": "^10.0.0",
         "email-templates": "^10.0.0",
         "express": "^4.17.1",
+        "google-auth-library": "^10.3.0",
         "googleapis": "^105.0.0",
         "jsonwebtoken": "^8.5.1",
         "module-alias": "^2.2.2",
@@ -3242,9 +3243,9 @@
       }
     },
     "node_modules/bignumber.js": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
-      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
       "engines": {
         "node": "*"
       }
@@ -4021,6 +4022,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/debug": {
@@ -4808,6 +4817,28 @@
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -4930,6 +4961,17 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/formidable": {
       "version": "2.1.2",
@@ -5071,15 +5113,66 @@
       }
     },
     "node_modules/gcp-metadata": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
-      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
+      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
       "dependencies": {
-        "gaxios": "^5.0.0",
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
         "json-bigint": "^1.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/gaxios": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.2.tgz",
+      "integrity": "sha512-/Szrn8nr+2TsQT1Gp8iIe/BEytJmbyfrbFh419DfGQSkEgNEhbPi7JRJuughjkTzPWgU9gBQf5AVu3DbHt0OXA==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/gensync": {
@@ -5208,28 +5301,85 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.9.0.tgz",
-      "integrity": "sha512-f7aQCJODJFmYWN6PeNKzgvy9LI2tYmXnzpNDHEjG5sDNPgGb2FXQyTBnXeSH+PAtpKESFD+LmHw3Ox3mN7e1Fg==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.3.0.tgz",
+      "integrity": "sha512-ylSE3RlCRZfZB56PFJSfUCuiuPq83Fx8hqu1KPWGK8FVdSaxlp/qkeMMX/DT/18xkwXIHvXEXkZsljRwfrdEfQ==",
       "dependencies": {
-        "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
-        "fast-text-encoding": "^1.0.0",
-        "gaxios": "^5.0.0",
-        "gcp-metadata": "^5.3.0",
-        "gtoken": "^6.1.0",
-        "jws": "^4.0.0",
-        "lru-cache": "^6.0.0"
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/gaxios": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.2.tgz",
+      "integrity": "sha512-/Szrn8nr+2TsQT1Gp8iIe/BEytJmbyfrbFh419DfGQSkEgNEhbPi7JRJuughjkTzPWgU9gBQf5AVu3DbHt0OXA==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.1.tgz",
+      "integrity": "sha512-rcX58I7nqpu4mbKztFeOAObbomBbHU2oIb/d3tJfF3dizGSApqtSwYJigGCooHdnMyQBIw8BrWyK96w3YXgr6A==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/google-p12-pem": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-4.0.1.tgz",
       "integrity": "sha512-WPkN4yGtz05WZ5EhtlxNDWPhC4JIic6G8ePitwUWy4l+XPVYec+a0j0Ts47PDtW59y3RwAhUd9/h9ZZ63px6RQ==",
+      "deprecated": "Package is no longer maintained",
       "dependencies": {
         "node-forge": "^1.3.1"
       },
@@ -5268,6 +5418,50 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/googleapis-common/node_modules/gcp-metadata": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
+      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
+      "dependencies": {
+        "gaxios": "^5.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/google-auth-library": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.9.0.tgz",
+      "integrity": "sha512-f7aQCJODJFmYWN6PeNKzgvy9LI2tYmXnzpNDHEjG5sDNPgGb2FXQyTBnXeSH+PAtpKESFD+LmHw3Ox3mN7e1Fg==",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^5.0.0",
+        "gcp-metadata": "^5.3.0",
+        "gtoken": "^6.1.0",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/gtoken": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-6.1.2.tgz",
+      "integrity": "sha512-4ccGpzz7YAr7lxrT2neugmXQ3hP9ho2gcaityLVkiUecAiwiy60Ii8gRbZeOsXV19fYaRjgBSshs8kXw+NKCPQ==",
+      "dependencies": {
+        "gaxios": "^5.0.1",
+        "google-p12-pem": "^4.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/googleapis-common/node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -5278,6 +5472,50 @@
       ],
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/googleapis/node_modules/gcp-metadata": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
+      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
+      "dependencies": {
+        "gaxios": "^5.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/googleapis/node_modules/google-auth-library": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.9.0.tgz",
+      "integrity": "sha512-f7aQCJODJFmYWN6PeNKzgvy9LI2tYmXnzpNDHEjG5sDNPgGb2FXQyTBnXeSH+PAtpKESFD+LmHw3Ox3mN7e1Fg==",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^5.0.0",
+        "gcp-metadata": "^5.3.0",
+        "gtoken": "^6.1.0",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/googleapis/node_modules/gtoken": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-6.1.2.tgz",
+      "integrity": "sha512-4ccGpzz7YAr7lxrT2neugmXQ3hP9ho2gcaityLVkiUecAiwiy60Ii8gRbZeOsXV19fYaRjgBSshs8kXw+NKCPQ==",
+      "dependencies": {
+        "gaxios": "^5.0.1",
+        "google-p12-pem": "^4.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/gopd": {
@@ -5304,16 +5542,65 @@
       "dev": true
     },
     "node_modules/gtoken": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-6.1.2.tgz",
-      "integrity": "sha512-4ccGpzz7YAr7lxrT2neugmXQ3hP9ho2gcaityLVkiUecAiwiy60Ii8gRbZeOsXV19fYaRjgBSshs8kXw+NKCPQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
       "dependencies": {
-        "gaxios": "^5.0.1",
-        "google-p12-pem": "^4.0.0",
+        "gaxios": "^7.0.0",
         "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18"
+      }
+    },
+    "node_modules/gtoken/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gtoken/node_modules/gaxios": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.2.tgz",
+      "integrity": "sha512-/Szrn8nr+2TsQT1Gp8iIe/BEytJmbyfrbFh419DfGQSkEgNEhbPi7JRJuughjkTzPWgU9gBQf5AVu3DbHt0OXA==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gtoken/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gtoken/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/has-flag": {
@@ -6645,11 +6932,11 @@
       }
     },
     "node_modules/jwa": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
+        "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
@@ -7690,6 +7977,25 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
       "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -9973,6 +10279,14 @@
       },
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dotenv": "^10.0.0",
     "email-templates": "^10.0.0",
     "express": "^4.17.1",
+    "express-rate-limit": "^8.1.0",
     "google-auth-library": "^10.3.0",
     "googleapis": "^105.0.0",
     "jsonwebtoken": "^8.5.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dotenv": "^10.0.0",
     "email-templates": "^10.0.0",
     "express": "^4.17.1",
+    "google-auth-library": "^10.3.0",
     "googleapis": "^105.0.0",
     "jsonwebtoken": "^8.5.1",
     "module-alias": "^2.2.2",

--- a/src/consts/errors.js
+++ b/src/consts/errors.js
@@ -91,6 +91,34 @@ const errors = {
     code: 'EMAIL_NOT_SENT',
     message: 'Email has not been sent.'
   },
+  INVALID_TOKEN_ISSUER: {
+    code: 'INVALID_TOKEN_ISSUER',
+    message: 'Invalid token issuer'
+  },
+  EMAIL_NOT_VERIFIED: {
+    code: 'EMAIL_NOT_VERIFIED',
+    message: 'Email not verified by Google'
+  },
+  MISSING_SUB_CLAIM: {
+    code: 'MISSING_SUB_CLAIM',
+    message: 'Missing subject claim in token'
+  },
+  TOKEN_NOT_VALID: {
+    code: 'TOKEN_NOT_VALID',
+    message: 'Google token is not valid'
+  },
+  MISSING_TOKEN: {
+    code: 'MISSING_TOKEN',
+    message: 'Google token is required'
+  },
+  RATE_LIMIT_EXCEEDED: {
+    code: 'RATE_LIMIT_EXCEEDED',
+    message: 'Too many Google auth attempts'
+  },
+  AUTHENTICATION_FAILED: {
+    code: 'AUTHENTICATION_FAILED',
+    message: 'Google authentication failed'
+  },
   INVALID_LANGUAGE: {
     code: 'INVALID_LANGUAGE',
     message: `The language name is invalid. Possible options: ${APP_LANG_ENUM.join(', ')}.`

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -87,15 +87,44 @@ const updatePassword = async (req, res) => {
 }
 
 const googleAuth = async (req, res) => {
-  const { token } = req.body
-  const tokens = await authService.googleAuth(token)
+  try {
+    const { token } = req.body
 
-  res.cookie(ACCESS_TOKEN, tokens.accessToken, COOKIE_OPTIONS)
-  res.cookie(REFRESH_TOKEN, tokens.refreshToken, COOKIE_OPTIONS)
+    if (!token) {
+      return res.status(422).json({
+        error: 'MISSING_TOKEN',
+        message: 'Google token is required'
+      })
+    }
 
-  delete tokens.refreshToken
+    const tokens = await authService.googleAuth(token)
 
-  res.status(200).json(tokens)
+    res.cookie(ACCESS_TOKEN, tokens.accessToken, COOKIE_OPTIONS)
+    res.cookie(REFRESH_TOKEN, tokens.refreshToken, COOKIE_OPTIONS)
+
+    delete tokens.refreshToken
+
+    res.status(200).json(tokens)
+  } catch (error) {
+    if (error.status === 422) {
+      return res.status(422).json({
+        error: error.code || 'INVALID_TOKEN',
+        message: error.message
+      })
+    }
+
+    if (error.message && (error.message.includes('Token used too early') || error.message.includes('Invalid token'))) {
+      return res.status(422).json({
+        error: 'TOKEN_NOT_VALID',
+        message: 'Google token is not valid'
+      })
+    }
+
+    return res.status(401).json({
+      error: 'AUTHENTICATION_FAILED',
+      message: 'Google authentication failed'
+    })
+  }
 }
 
 module.exports = {

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -86,11 +86,24 @@ const updatePassword = async (req, res) => {
   res.status(204).end()
 }
 
+const googleAuth = async (req, res) => {
+  const { token } = req.body
+  const tokens = await authService.googleAuth(token)
+
+  res.cookie(ACCESS_TOKEN, tokens.accessToken, COOKIE_OPTIONS)
+  res.cookie(REFRESH_TOKEN, tokens.refreshToken, COOKIE_OPTIONS)
+
+  delete tokens.refreshToken
+
+  res.status(200).json(tokens)
+}
+
 module.exports = {
   signup,
   login,
   logout,
   refreshAccessToken,
   sendResetPasswordEmail,
-  updatePassword
+  updatePassword,
+  googleAuth
 }

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -10,6 +10,16 @@ const { loginValidationSchema } = require('~/validation/schemas/login')
 const resetPasswordValidationSchema = require('~/validation/schemas/resetPassword')
 const forgotPasswordValidationSchema = require('~/validation/schemas/forgotPassword')
 
+const rateLimit = require('express-rate-limit')
+
+const googleAuthLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 5,
+  message: { error: 'RATE_LIMIT_EXCEEDED', message: 'Too many Google auth attempts' },
+  standardHeaders: true,
+  legacyHeaders: false
+})
+
 router.post(
   '/signup',
   validationMiddleware(signupValidationSchema),
@@ -32,6 +42,6 @@ router.patch(
   asyncWrapper(authController.updatePassword)
 )
 
-router.post('/google-auth', asyncWrapper(authController.googleAuth))
+router.post('/google-auth', googleAuthLimiter, asyncWrapper(authController.googleAuth))
 
 module.exports = router

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -32,4 +32,6 @@ router.patch(
   asyncWrapper(authController.updatePassword)
 )
 
+router.post('/google-auth', asyncWrapper(authController.googleAuth))
+
 module.exports = router

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -19,6 +19,7 @@ const {
 } = require('~/configs/config')
 
 const client = new OAuth2Client(GMAIL_CLIENT_ID)
+const crypto = require('crypto')
 
 const authService = {
   signup: async (role, firstName, lastName, email, password, language) => {
@@ -130,7 +131,7 @@ const authService = {
 
     if (!user) {
       const safeLastName = lastName || firstName || 'User'
-      const safePassword = 'google_auth_user'
+      const safePassword = crypto.randomBytes(32).toString('hex')
 
       user = await createUser('student', firstName || 'Google', safeLastName, email, safePassword, 'en')
       await privateUpdateUser(user._id, { isEmailConfirmed: true })

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -13,6 +13,12 @@ const emailSubject = require('~/consts/emailSubject')
 const {
   tokenNames: { REFRESH_TOKEN, RESET_TOKEN, CONFIRM_TOKEN }
 } = require('~/consts/auth')
+const { OAuth2Client } = require('google-auth-library')
+const {
+  config: { GMAIL_CLIENT_ID }
+} = require('~/configs/config')
+
+const client = new OAuth2Client(GMAIL_CLIENT_ID)
 
 const authService = {
   signup: async (role, firstName, lastName, email, password, language) => {
@@ -34,7 +40,7 @@ const authService = {
       throw createError(401, USER_NOT_FOUND)
     }
 
-    const checkedPassword = (password === user.password) || isFromGoogle
+    const checkedPassword = password === user.password || isFromGoogle
 
     if (!checkedPassword) {
       throw createError(401, INCORRECT_CREDENTIALS)
@@ -109,6 +115,28 @@ const authService = {
     await emailService.sendEmail(email, emailSubject.SUCCESSFUL_PASSWORD_RESET, language, {
       firstName
     })
+  },
+
+  googleAuth: async (idToken) => {
+    const ticket = await client.verifyIdToken({
+      idToken: idToken,
+      audience: GMAIL_CLIENT_ID
+    })
+
+    const payload = ticket.getPayload()
+    const { email, given_name: firstName, family_name: lastName } = payload
+
+    let user = await getUserByEmail(email)
+
+    if (!user) {
+      const safeLastName = lastName || firstName || 'User'
+      const safePassword = 'google_auth_user'
+
+      user = await createUser('student', firstName || 'Google', safeLastName, email, safePassword, 'en')
+      await privateUpdateUser(user._id, { isEmailConfirmed: true })
+    }
+
+    return authService.login(email, '', true)
   }
 }
 

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -7,7 +7,10 @@ const {
   INCORRECT_CREDENTIALS,
   BAD_RESET_TOKEN,
   BAD_REFRESH_TOKEN,
-  USER_NOT_FOUND
+  USER_NOT_FOUND,
+  INVALID_TOKEN_ISSUER,
+  EMAIL_NOT_VERIFIED,
+  MISSING_SUB_CLAIM
 } = require('~/consts/errors')
 const emailSubject = require('~/consts/emailSubject')
 const {
@@ -125,6 +128,19 @@ const authService = {
     })
 
     const payload = ticket.getPayload()
+
+    if (payload.iss !== 'accounts.google.com' && payload.iss !== 'https://accounts.google.com') {
+      throw createError(422, INVALID_TOKEN_ISSUER)
+    }
+
+    if (!payload.email_verified) {
+      throw createError(422, EMAIL_NOT_VERIFIED)
+    }
+
+    if (!payload.sub) {
+      throw createError(422, MISSING_SUB_CLAIM)
+    }
+
     const { email, given_name: firstName, family_name: lastName } = payload
 
     let user = await getUserByEmail(email)

--- a/src/test/integration/controllers/auth.spec.js
+++ b/src/test/integration/controllers/auth.spec.js
@@ -12,7 +12,7 @@ describe('Auth controller', () => {
   let app, server, signupResponse
 
   beforeAll(async () => {
-    ; ({ app, server } = await serverInit())
+    ;({ app, server } = await serverInit())
   })
 
   beforeEach(async () => {
@@ -112,6 +112,37 @@ describe('Auth controller', () => {
       const response = await app.patch('/auth/reset-password/invalid-token').send({ password: 'valid_pass1' })
 
       expectError(400, errors.BAD_RESET_TOKEN, response)
+    })
+  })
+
+  describe('Google Auth endpoint', () => {
+    it('should authenticate user with valid Google token', async () => {
+      const mockVerifyIdToken = jest.fn().mockResolvedValue({
+        getPayload: () => ({
+          email: 'googleuser@gmail.com',
+          given_name: 'Google',
+          family_name: 'User'
+        })
+      })
+
+      const { OAuth2Client } = require('google-auth-library')
+      OAuth2Client.prototype.verifyIdToken = mockVerifyIdToken
+
+      const response = await app.post('/auth/google-auth').send({ token: 'valid-google-token' })
+
+      expect(response.status).toBe(200)
+      expect(response.body).toHaveProperty('accessToken')
+      expect(mockVerifyIdToken).toHaveBeenCalled()
+    })
+
+    it('should throw error for invalid Google token', async () => {
+      const mockVerifyIdToken = jest.fn().mockRejectedValue(new Error('Invalid token'))
+      const { OAuth2Client } = require('google-auth-library')
+      OAuth2Client.prototype.verifyIdToken = mockVerifyIdToken
+
+      const response = await app.post('/auth/google-auth').send({ token: 'invalid-token' })
+
+      expect(response.status).toBe(500)
     })
   })
 })

--- a/src/test/integration/controllers/auth.spec.js
+++ b/src/test/integration/controllers/auth.spec.js
@@ -119,6 +119,9 @@ describe('Auth controller', () => {
     it('should authenticate user with valid Google token', async () => {
       const mockVerifyIdToken = jest.fn().mockResolvedValue({
         getPayload: () => ({
+          iss: 'accounts.google.com',
+          email_verified: true,
+          sub: 'test123',
           email: 'googleuser@gmail.com',
           given_name: 'Google',
           family_name: 'User'
@@ -132,7 +135,6 @@ describe('Auth controller', () => {
 
       expect(response.status).toBe(200)
       expect(response.body).toHaveProperty('accessToken')
-      expect(mockVerifyIdToken).toHaveBeenCalled()
     })
 
     it('should throw error for invalid Google token', async () => {
@@ -142,7 +144,57 @@ describe('Auth controller', () => {
 
       const response = await app.post('/auth/google-auth').send({ token: 'invalid-token' })
 
-      expect(response.status).toBe(500)
+      expect(response.status).toBe(422)
+      expect(response.body.error).toBe('TOKEN_NOT_VALID')
+    })
+
+    it('should return 422 for invalid issuer', async () => {
+      const mockVerifyIdToken = jest.fn().mockResolvedValue({
+        getPayload: () => ({
+          iss: 'invalid-issuer.com',
+          email_verified: true,
+          sub: 'test123',
+          email: 'test@gmail.com',
+          given_name: 'Test',
+          family_name: 'User'
+        })
+      })
+
+      const { OAuth2Client } = require('google-auth-library')
+      OAuth2Client.prototype.verifyIdToken = mockVerifyIdToken
+
+      const response = await app.post('/auth/google-auth').send({ token: 'invalid-issuer-token' })
+
+      expect(response.status).toBe(422)
+      expect(response.body.error).toBe('INVALID_TOKEN_ISSUER')
+    })
+
+    it('should return 422 for unverified email', async () => {
+      const mockVerifyIdToken = jest.fn().mockResolvedValue({
+        getPayload: () => ({
+          iss: 'accounts.google.com',
+          email_verified: false,
+          sub: 'test123',
+          email: 'test@gmail.com',
+          given_name: 'Test',
+          family_name: 'User'
+        })
+      })
+
+      const { OAuth2Client } = require('google-auth-library')
+      OAuth2Client.prototype.verifyIdToken = mockVerifyIdToken
+
+      const response = await app.post('/auth/google-auth').send({ token: 'unverified-email-token' })
+
+      expect(response.status).toBe(422)
+      expect(response.body.error).toBe('EMAIL_NOT_VERIFIED')
+    })
+
+    it('should return 422 for missing token', async () => {
+      const response = await app.post('/auth/google-auth').send({})
+
+      expect(response.status).toBe(422)
+      expect(response.body.error).toBe('MISSING_TOKEN')
     })
   })
 })


### PR DESCRIPTION
## Changes Made
- Added POST `/auth/google-auth` endpoint
- Integrated `google-auth-library` for token verification
- Added user creation/authentication flow for Google users
- Added tests for Google Auth functionality

## Dependencies
- Added `google-auth-library` package

## Frontend Integration Required
- Frontend needs to send Google ID token to `/auth/google-auth` endpoint
- Token should be extracted from `response.credential` (Google Identity Services)

## Environment Variables
- `GMAIL_CLIENT_ID` - Google OAuth Client ID  
- `GMAIL_CLIENT_SECRET` - Google OAuth Client Secret