### PR TITLE
feat: add Swagger documentation to the project (#37)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -27,9 +27,7 @@ module.exports = {
   coverageReporters: ['html', 'lcov'],
   coverageDirectory: '<rootDir>/src/test/coverage',
   testTimeout: 12000,
-  testMatch: [
-    '<rootDir>/src/test/integration/**/*.spec.js',
-    '<rootDir>/src/test/unit/**/*.spec.js'
-  ],
-  testResultsProcessor: 'jest-sonar-reporter'
+  testMatch: ['<rootDir>/src/test/integration/**/*.spec.js', '<rootDir>/src/test/unit/**/*.spec.js'],
+  testResultsProcessor: 'jest-sonar-reporter',
+  coveragePathIgnorePatterns: ['/node_modules/', '/src/docs/', '/src/configs/swagger.js']
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,8 @@
         "multer": "^1.4.5-lts.1",
         "nodemailer": "^6.7.7",
         "pug": "^3.0.2",
+        "swagger-jsdoc": "^6.2.8",
+        "swagger-ui-express": "^5.0.1",
         "winston": "^3.8.0",
         "winston-mongodb": "^5.0.7"
       },
@@ -59,6 +61,46 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -1974,6 +2016,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
+    },
     "node_modules/@ladjs/country-language": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@ladjs/country-language/-/country-language-1.0.3.tgz",
@@ -2104,6 +2151,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true
     },
     "node_modules/@selderee/plugin-htmlparser2": {
       "version": "0.6.0",
@@ -2786,6 +2839,11 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
+    },
     "node_modules/@types/luxon": {
       "version": "3.3.8",
       "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.8.tgz",
@@ -3049,8 +3107,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-differ": {
       "version": "3.0.0",
@@ -3479,6 +3536,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -4184,7 +4246,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -4570,7 +4631,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6505,7 +6565,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -6982,6 +7041,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead."
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -6991,6 +7056,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead."
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
@@ -7017,6 +7088,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
@@ -7953,6 +8029,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "peer": true
     },
     "node_modules/optional-require": {
       "version": "1.1.8",
@@ -9546,6 +9628,94 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "dependencies": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.29.0.tgz",
+      "integrity": "sha512-gqs7Md3AxP4mbpXAq31o5QW+wGUZsUzVatg70yXpUR245dfIis5jAzufBd+UQM/w2xSfrhvA1eqsrgnl2PbezQ==",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/tar": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
@@ -9893,6 +10063,14 @@
       "integrity": "sha512-jOWVmzVceKlVVdwjNSenT4PbGghU0SBIizAev8ofZVgivk/TVHXSbNL8LP6M3spZvkR9/QolkyJavGSX5Cs0UA==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.15",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
+      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {
@@ -10356,6 +10534,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "multer": "^1.4.5-lts.1",
     "nodemailer": "^6.7.7",
     "pug": "^3.0.2",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.1",
     "winston": "^3.8.0",
     "winston-mongodb": "^5.0.7"
   },

--- a/src/configs/swagger.js
+++ b/src/configs/swagger.js
@@ -1,0 +1,27 @@
+const swaggerJsdoc = require('swagger-jsdoc')
+const swaggerUi = require('swagger-ui-express')
+
+const options = {
+  definition: {
+    openapi: '3.1.0',
+    info: {
+      title: 'Space2Study API',
+      version: '0.0.1',
+      description: 'API documentation for Space2Study project'
+    },
+    servers: [
+      {
+        url: process.env.BASE_URL || 'http://localhost:8080',
+        description: 'Development server'
+      }
+    ]
+  },
+  apis: ['./src/docs/components/*.yaml', './src/docs/paths/*.yaml']
+}
+
+const swaggerSpec = swaggerJsdoc(options)
+
+module.exports = {
+  swaggerSpec,
+  swaggerUi
+}

--- a/src/docs/components/schemas.yaml
+++ b/src/docs/components/schemas.yaml
@@ -1,32 +1,42 @@
 components:
   schemas:
-    # Requests
+    #Requests
     SignupRequest:
       type: object
       required:
-        - email
-        - password
         - firstName
         - lastName
+        - email
+        - role
+        - password
       properties:
-        email:
-          type: string
-          format: email
-          example: "user@example.com"
-        password:
-          type: string
-          minLength: 6
-          example: "password123"
         firstName:
           type: string
+          minLength: 1
+          maxLength: 30
+          pattern: "^[a-zа-яєії]+$"
           example: "John"
         lastName:
           type: string
+          minLength: 1
+          maxLength: 30
+          pattern: "^[a-zа-яєії]+$"
           example: "Doe"
+        email:
+          type: string
+          format: email
+          pattern: "^([a-z\\d]+([._-][a-z\\d]+)*)@([a-z\\d]+([.-][a-z\\d]+)*\\.[a-z]{2,})$"
+          example: "user@example.com"
         role:
           type: string
-          enum: [student, tutor]
+          enum: [student, tutor, admin, superadmin]
           example: "student"
+        password:
+          type: string
+          minLength: 8
+          maxLength: 25
+          pattern: "^(?=.*\\d)(?=.*[a-zа-яєії])\\S+$"
+          example: "Password123"
 
     LoginRequest:
       type: object
@@ -40,7 +50,7 @@ components:
           example: "user@example.com"
         password:
           type: string
-          example: "password123"
+          example: "Password123"
 
     GoogleAuthRequest:
       type: object
@@ -69,49 +79,28 @@ components:
       properties:
         password:
           type: string
-          minLength: 6
-          example: "newpassword123"
+          minLength: 8
+          maxLength: 25
+          pattern: "^(?=.*\\d)(?=.*[a-zа-яєії])\\S+$"
+          example: "NewPassword123"
 
-    # Answers
+    # Responses
+    SignupResponse:
+      type: object
+      properties:
+        userId:
+          type: string
+          example: "507f1f77bcf86cd799439011"
+        userEmail:
+          type: string
+          example: "user@example.com"
+
     AuthResponse:
       type: object
       properties:
         accessToken:
           type: string
           description: JWT access token
-          example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
-        user:
-          type: object
-          properties:
-            id:
-              type: string
-              example: "507f1f77bcf86cd799439011"
-            email:
-              type: string
-              example: "user@example.com"
-            firstName:
-              type: string
-              example: "John"
-            lastName:
-              type: string
-              example: "Doe"
-            role:
-              type: string
-              example: "student"
-
-    MessageResponse:
-      type: object
-      properties:
-        message:
-          type: string
-          example: "Password reset email sent successfully"
-
-    RefreshTokenResponse:
-      type: object
-      properties:
-        accessToken:
-          type: string
-          description: New JWT access token
           example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
 
     ErrorResponse:

--- a/src/docs/components/schemas.yaml
+++ b/src/docs/components/schemas.yaml
@@ -1,0 +1,125 @@
+components:
+  schemas:
+    # Requests
+    SignupRequest:
+      type: object
+      required:
+        - email
+        - password
+        - firstName
+        - lastName
+      properties:
+        email:
+          type: string
+          format: email
+          example: "user@example.com"
+        password:
+          type: string
+          minLength: 6
+          example: "password123"
+        firstName:
+          type: string
+          example: "John"
+        lastName:
+          type: string
+          example: "Doe"
+        role:
+          type: string
+          enum: [student, tutor]
+          example: "student"
+
+    LoginRequest:
+      type: object
+      required:
+        - email
+        - password
+      properties:
+        email:
+          type: string
+          format: email
+          example: "user@example.com"
+        password:
+          type: string
+          example: "password123"
+
+    GoogleAuthRequest:
+      type: object
+      required:
+        - token
+      properties:
+        token:
+          type: string
+          description: Google OAuth token
+          example: "eyJhbGciOiJSUzI1NiIsImtpZCI6IjdkYzBiMjVhM..."
+
+    ForgotPasswordRequest:
+      type: object
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          format: email
+          example: "user@example.com"
+
+    ResetPasswordRequest:
+      type: object
+      required:
+        - password
+      properties:
+        password:
+          type: string
+          minLength: 6
+          example: "newpassword123"
+
+    # Answers
+    AuthResponse:
+      type: object
+      properties:
+        accessToken:
+          type: string
+          description: JWT access token
+          example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+        user:
+          type: object
+          properties:
+            id:
+              type: string
+              example: "507f1f77bcf86cd799439011"
+            email:
+              type: string
+              example: "user@example.com"
+            firstName:
+              type: string
+              example: "John"
+            lastName:
+              type: string
+              example: "Doe"
+            role:
+              type: string
+              example: "student"
+
+    MessageResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Password reset email sent successfully"
+
+    RefreshTokenResponse:
+      type: object
+      properties:
+        accessToken:
+          type: string
+          description: New JWT access token
+          example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+
+    ErrorResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Invalid credentials"
+        status:
+          type: integer
+          example: 400

--- a/src/docs/paths/auth.yaml
+++ b/src/docs/paths/auth.yaml
@@ -1,0 +1,186 @@
+/auth/signup:
+  post:
+    summary: Register new user
+    description: Creates a new user account
+    tags:
+      - Authentication
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SignupRequest'
+    responses:
+      '201':
+        description: User created successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthResponse'
+      '400':
+        description: Validation error
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorResponse'
+      '409':
+        description: User already exists
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorResponse'
+
+/auth/login:
+  post:
+    summary: User login
+    description: Authenticates user with email and password
+    tags:
+      - Authentication
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/LoginRequest'
+    responses:
+      '200':
+        description: Login successful
+        headers:
+          Set-Cookie:
+            description: Sets access and refresh token cookies
+            schema:
+              type: string
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthResponse'
+      '401':
+        description: Invalid credentials
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorResponse'
+
+/auth/google-auth:
+  post:
+    summary: Google OAuth authentication
+    description: Authenticates user using Google OAuth token
+    tags:
+      - Authentication
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/GoogleAuthRequest'
+    responses:
+      '200':
+        description: Authentication successful
+        headers:
+          Set-Cookie:
+            description: Sets access and refresh token cookies
+            schema:
+              type: string
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthResponse'
+      '400':
+        description: Invalid token
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorResponse'
+
+/auth/logout:
+  post:
+    summary: User logout
+    description: Logs out user and clears authentication cookies
+    tags:
+      - Authentication
+    responses:
+      '200':
+        description: Logout successful
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MessageResponse'
+
+/auth/refresh:
+  get:
+    summary: Refresh access token
+    description: Gets new access token using refresh token from cookies
+    tags:
+      - Authentication
+    responses:
+      '200':
+        description: Token refreshed successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefreshTokenResponse'
+      '401':
+        description: Invalid or expired refresh token
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorResponse'
+
+/auth/forgot-password:
+  post:
+    summary: Send password reset email
+    description: Sends password reset link to user's email
+    tags:
+      - Authentication
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ForgotPasswordRequest'
+    responses:
+      '200':
+        description: Reset email sent successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MessageResponse'
+      '404':
+        description: User not found
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorResponse'
+
+/auth/reset-password/{token}:
+  patch:
+    summary: Reset password
+    description: Resets user password using reset token
+    tags:
+      - Authentication
+    parameters:
+      - in: path
+        name: token
+        required: true
+        schema:
+          type: string
+        description: Password reset token
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ResetPasswordRequest'
+    responses:
+      '200':
+        description: Password reset successful
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MessageResponse'
+      '400':
+        description: Invalid or expired token
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorResponse'

--- a/src/docs/paths/auth.yaml
+++ b/src/docs/paths/auth.yaml
@@ -16,7 +16,7 @@
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AuthResponse'
+              $ref: '#/components/schemas/SignupResponse'
       '400':
         description: Validation error
         content:
@@ -99,12 +99,8 @@
     tags:
       - Authentication
     responses:
-      '200':
+      '204':
         description: Logout successful
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/MessageResponse'
 
 /auth/refresh:
   get:
@@ -115,10 +111,15 @@
     responses:
       '200':
         description: Token refreshed successfully
+        headers:
+          Set-Cookie:
+            description: Sets access and refresh token cookies
+            schema:
+              type: string
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RefreshTokenResponse'
+              $ref: '#/components/schemas/AuthResponse'
       '401':
         description: Invalid or expired refresh token
         content:
@@ -139,12 +140,8 @@
           schema:
             $ref: '#/components/schemas/ForgotPasswordRequest'
     responses:
-      '200':
+      '204':
         description: Reset email sent successfully
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/MessageResponse'
       '404':
         description: User not found
         content:
@@ -172,12 +169,8 @@
           schema:
             $ref: '#/components/schemas/ResetPasswordRequest'
     responses:
-      '200':
+      '204':
         description: Password reset successful
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/MessageResponse'
       '400':
         description: Invalid or expired token
         content:

--- a/src/initialization/initialization.js
+++ b/src/initialization/initialization.js
@@ -8,6 +8,7 @@ const {
 const router = require('~/routes')
 const { createNotFoundError } = require('~/utils/errorsHelper')
 const errorMiddleware = require('~/middlewares/error')
+const { swaggerSpec, swaggerUi } = require('~/configs/swagger')
 
 const initialization = (app) => {
   app.use(express.json({ limit: '10mb' }))
@@ -21,6 +22,13 @@ const initialization = (app) => {
       allowedHeaders: 'Content-Type, Authorization'
     })
   )
+
+  app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec))
+
+  app.get('/api/docs.json', (req, res) => {
+    res.setHeader('Content-Type', 'application/json')
+    res.send(swaggerSpec)
+  })
 
   app.use('/', router)
 


### PR DESCRIPTION
## Summary
Added Swagger/OpenAPI documentation for authentication endpoints.

## Changes
- Installed `swagger-jsdoc` and `swagger-ui-express`
- Created Swagger configuration in `src/configs/swagger.js`
- Added documentation structure in `src/docs/` folder
- Documented all 7 auth endpoints with accurate validation schemas
- Excluded Swagger files from test coverage

## Documentation
Available at: `http://localhost:8080/api/docs`

Includes: signup, login, google-auth, logout, refresh, forgot-password, reset-password
