### PR TITLE
test: #45 add unit test for language middleware

### DIFF
--- a/src/test/unit/middlewares/appLanguage.spec.js
+++ b/src/test/unit/middlewares/appLanguage.spec.js
@@ -1,0 +1,38 @@
+const langMiddleware = require('~/middlewares/appLanguage')
+const { INVALID_LANGUAGE } = require('~/consts/errors')
+const { createError } = require('~/utils/errorsHelper')
+const {
+  enums: { APP_LANG_ENUM }
+} = require('~/consts/validation')
+
+describe('langMiddleware', () => {
+  let req, res, next
+  beforeEach(() => {
+    req = {}
+    res = {}
+    next = jest.fn()
+  })
+
+  it.each(APP_LANG_ENUM)('should set req.lang and call next if language is valid (%s)', (lang) => {
+    req.acceptsLanguages = jest.fn().mockReturnValue(lang)
+    langMiddleware(req, res, next)
+
+    expect(req.lang).toBe(lang)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should throw an error if language is invalid', () => {
+    req.acceptsLanguages = jest.fn().mockReturnValue(false)
+    const expectedError = createError(400, INVALID_LANGUAGE)
+
+    expect(() => langMiddleware(req, res, next)).toThrowError(
+      expect.objectContaining({
+        message: expectedError.message,
+        status: expectedError.status,
+        code: expectedError.code
+      })
+    )
+
+    expect(next).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Added unit test for the language middleware.

Test cases included:
- should set req.lang and call next if language is valid
- should throw an error if language is invalid

Related to [(SP: 1) Write unit test for language middleware #45](https://github.com/Space2Study-UA-4427-4288-01/Issues/issues/45)