### PR TITLE
feat: implement email confirmation functionality

### DIFF
--- a/src/consts/errors.js
+++ b/src/consts/errors.js
@@ -44,6 +44,14 @@ const errors = {
     code: 'EMAIL_NOT_CONFIRMED',
     message: 'Please confirm your email to login.'
   },
+  EMAIL_ALREADY_CONFIRMED: {
+    code: 'EMAIL_ALREADY_CONFIRMED',
+    message: 'Your email address has already been verified.'
+  },
+  BAD_CONFIRM_TOKEN: {
+    code: 'BAD_CONFIRM_TOKEN',
+    message: 'The confirmation token is either invalid or has expired.'
+  },
   NOT_FOUND: {
     code: 'NOT_FOUND',
     message: 'The requested URL was not found.'

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -31,6 +31,13 @@ const signup = async (req, res) => {
   res.status(201).json(userData)
 }
 
+const confirmEmail = async (req, res) => {
+  const { token } = req.params
+  const lang = req.lang
+  await authService.confirmEmail(token, lang)
+  res.status(204).end()
+}
+
 const login = async (req, res) => {
   const { email, password } = req.body
 
@@ -140,5 +147,6 @@ module.exports = {
   refreshAccessToken,
   sendResetPasswordEmail,
   updatePassword,
-  googleAuth
+  googleAuth,
+  confirmEmail
 }

--- a/src/docs/paths/auth.yaml
+++ b/src/docs/paths/auth.yaml
@@ -92,6 +92,29 @@
             schema:
               $ref: '#/components/schemas/ErrorResponse'
 
+/auth/confirm/{token}:
+  get:
+    summary: Confirm email
+    description: Confirms user's email address using confirmation token sent during registration
+    tags:
+      - Authentication
+    parameters:
+      - in: path
+        name: token
+        required: true
+        schema:
+          type: string
+        description: Email confirmation token from registration email
+    responses:
+      '204':
+        description: Email confirmed successfully
+      '400':
+        description: Invalid or expired confirmation token
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorResponse'
+
 /auth/logout:
   post:
     summary: User logout

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -63,4 +63,6 @@ router.patch(
 
 router.post('/google-auth', googleAuthLimiter, asyncWrapper(authController.googleAuth))
 
+router.get('/confirm/:token', langMiddleware, asyncWrapper(authController.confirmEmail))
+
 module.exports = router

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -10,7 +10,9 @@ const {
   USER_NOT_FOUND,
   INVALID_TOKEN_ISSUER,
   EMAIL_NOT_VERIFIED,
-  MISSING_SUB_CLAIM
+  MISSING_SUB_CLAIM,
+  EMAIL_ALREADY_CONFIRMED,
+  BAD_CONFIRM_TOKEN
 } = require('~/consts/errors')
 const emailSubject = require('~/consts/emailSubject')
 const {
@@ -31,6 +33,7 @@ const authService = {
     const confirmToken = tokenService.generateConfirmToken({ id: user._id, role })
     await tokenService.saveToken(user._id, confirmToken, CONFIRM_TOKEN)
     await emailService.sendEmail(email, emailSubject.EMAIL_CONFIRMATION, language, { confirmToken, email, firstName })
+
     return {
       userId: user._id,
       userEmail: user.email
@@ -102,6 +105,34 @@ const authService = {
     await tokenService.saveToken(_id, resetToken, RESET_TOKEN)
 
     await emailService.sendEmail(email, emailSubject.RESET_PASSWORD, language, { resetToken, email, firstName })
+  },
+
+  confirmEmail: async (confirmToken, _language) => {
+    const tokenData = tokenService.validateConfirmToken(confirmToken)
+
+    if (!tokenData) {
+      throw createError(400, BAD_CONFIRM_TOKEN)
+    }
+
+    const { id: userId } = tokenData
+    const user = await getUserById(userId)
+
+    if (!user) {
+      throw createError(404, USER_NOT_FOUND)
+    }
+
+    if (user.isEmailConfirmed) {
+      throw createError(400, EMAIL_ALREADY_CONFIRMED)
+    }
+
+    const tokenFromDB = await tokenService.findToken(confirmToken, CONFIRM_TOKEN)
+
+    if (!tokenFromDB) {
+      throw createError(400, BAD_CONFIRM_TOKEN)
+    }
+
+    await privateUpdateUser(userId, { isEmailConfirmed: true })
+    await tokenService.removeConfirmToken(confirmToken)
   },
 
   updatePassword: async (resetToken, password, language) => {

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -1,6 +1,7 @@
 const tokenService = require('~/services/token')
 const emailService = require('~/services/email')
 const { getUserByEmail, createUser, privateUpdateUser, getUserById } = require('~/services/user')
+const User = require('~/models/user')
 const { createError } = require('~/utils/errorsHelper')
 const {
   EMAIL_NOT_CONFIRMED,
@@ -84,7 +85,13 @@ const authService = {
       throw createError(400, BAD_REFRESH_TOKEN)
     }
 
-    const { _id, lastLoginAs, isFirstLogin } = await getUserById(tokenData.id)
+    const user = await getUserById(tokenData.id)
+
+    if (!user) {
+      throw createError(400, BAD_REFRESH_TOKEN)
+    }
+
+    const { _id, lastLoginAs, isFirstLogin } = user
 
     const tokens = tokenService.generateTokens({ id: _id, role: lastLoginAs, isFirstLogin })
     await tokenService.saveToken(_id, tokens.refreshToken, REFRESH_TOKEN)
@@ -115,23 +122,34 @@ const authService = {
     }
 
     const { id: userId } = tokenData
-    const user = await getUserById(userId)
-
-    if (!user) {
-      throw createError(404, USER_NOT_FOUND)
-    }
-
-    if (user.isEmailConfirmed) {
-      throw createError(400, EMAIL_ALREADY_CONFIRMED)
-    }
-
     const tokenFromDB = await tokenService.findToken(confirmToken, CONFIRM_TOKEN)
 
     if (!tokenFromDB) {
       throw createError(400, BAD_CONFIRM_TOKEN)
     }
 
-    await privateUpdateUser(userId, { isEmailConfirmed: true })
+    const updatedUser = await User.findOneAndUpdate(
+      {
+        _id: userId,
+        isEmailConfirmed: false
+      },
+      {
+        $set: { isEmailConfirmed: true }
+      },
+      {
+        new: true
+      }
+    ).exec()
+
+    if (!updatedUser) {
+      const user = await getUserById(userId)
+
+      if (!user) {
+        throw createError(404, USER_NOT_FOUND)
+      }
+
+      throw createError(400, EMAIL_ALREADY_CONFIRMED)
+    }
     await tokenService.removeConfirmToken(confirmToken)
   },
 

--- a/src/services/email.js
+++ b/src/services/email.js
@@ -1,4 +1,5 @@
 const EmailTemplates = require('email-templates')
+const path = require('path')
 const { sendMail } = require('~/utils/mailer')
 const { templateList } = require('~/emails')
 const {
@@ -7,7 +8,11 @@ const {
 const { createError } = require('~/utils/errorsHelper')
 const { TEMPLATE_NOT_FOUND } = require('~/consts/errors')
 
-const emailTemplates = new EmailTemplates()
+const emailTemplates = new EmailTemplates({
+  views: {
+    root: path.resolve(__dirname, '../emails')
+  }
+})
 
 const emailService = {
   sendEmail: async (email, subject, language, text = {}) => {

--- a/src/services/email.js
+++ b/src/services/email.js
@@ -1,5 +1,5 @@
 const EmailTemplates = require('email-templates')
-const path = require('path')
+const path = require('node:path')
 const { sendMail } = require('~/utils/mailer')
 const { templateList } = require('~/emails')
 const {

--- a/src/test/integration/controllers/auth.spec.js
+++ b/src/test/integration/controllers/auth.spec.js
@@ -15,7 +15,6 @@ const tokenService = require('~/services/token')
 const Token = require('~/models/token')
 const { expectError, genEmail, genValidPassword, genUUID } = require('~/test/helpers')
 
-
 describe('Auth controller', () => {
   let app, server, signupResponse
 
@@ -313,6 +312,118 @@ describe('Auth controller', () => {
       const response = await app.post('/auth/google-auth').send({})
       expect(response.status).toBe(422)
       expect(response.body.error).toBe('MISSING_TOKEN')
+    })
+  })
+
+  describe('Confirm Email endpoint', () => {
+    it('should confirm email with valid token', async () => {
+      const email = genEmail('confirm')
+      const password = genValidPassword()
+
+      const signup = await app.post('/auth/signup').send({
+        role: 'student',
+        firstName: 'Confirm',
+        lastName: 'Test',
+        email,
+        password
+      })
+
+      expect(signup.status).toBe(201)
+
+      const { userId } = signup.body
+      const tokenDoc = await Token.findOne({ user: userId }).exec()
+      const confirmToken = tokenDoc.confirmToken
+      expect(confirmToken).toBeDefined()
+
+      let user = await User.findById(userId).select('+isEmailConfirmed').exec()
+      expect(user.isEmailConfirmed).toBe(false)
+
+      const confirmRes = await app.get(`/auth/confirm/${confirmToken}`)
+      expect(confirmRes.status).toBe(204)
+
+      user = await User.findById(userId).select('+isEmailConfirmed').exec()
+      expect(user.isEmailConfirmed).toBe(true)
+
+      const token = await Token.findOne({ confirmToken }).exec()
+      expect(token).toBeNull()
+    })
+
+    it('should return 400 for invalid confirm token', async () => {
+      const response = await app.get('/auth/confirm/invalid-token-here')
+      expectError(400, errors.BAD_CONFIRM_TOKEN, response)
+    })
+
+    it('should block login before email confirmation', async () => {
+      const email = genEmail('blocked')
+      const password = genValidPassword()
+
+      const signup = await app.post('/auth/signup').send({
+        role: 'student',
+        firstName: 'Blocked',
+        lastName: 'Login',
+        email,
+        password
+      })
+
+      expect(signup.status).toBe(201)
+
+      const loginRes = await app.post('/auth/login').send({ email, password })
+      expectError(401, errors.EMAIL_NOT_CONFIRMED, loginRes)
+    })
+
+    it('should return 400 for already confirmed email', async () => {
+      const email = genEmail('alreadyconfirmed')
+      const password = genValidPassword()
+
+      const signup = await app.post('/auth/signup').send({
+        role: 'student',
+        firstName: 'Already',
+        lastName: 'Confirmed',
+        email,
+        password
+      })
+
+      expect(signup.status).toBe(201)
+
+      const tokenDoc = await Token.findOne({ user: signup.body.userId }).exec()
+      const confirmToken = tokenDoc.confirmToken
+      const firstConfirm = await app.get(`/auth/confirm/${confirmToken}`)
+
+      expect(firstConfirm.status).toBe(204)
+
+      const newToken = tokenService.generateConfirmToken({
+        id: signup.body.userId,
+        role: 'student'
+      })
+      await tokenService.saveToken(signup.body.userId, newToken, 'confirmToken')
+
+      const secondConfirm = await app.get(`/auth/confirm/${newToken}`)
+      expectError(400, errors.EMAIL_ALREADY_CONFIRMED, secondConfirm)
+    })
+
+    it('should allow login after email confirmation', async () => {
+      const email = genEmail('allowed')
+      const password = genValidPassword()
+
+      const signup = await app.post('/auth/signup').send({
+        role: 'student',
+        firstName: 'Allowed',
+        lastName: 'Login',
+        email,
+        password
+      })
+
+      expect(signup.status).toBe(201)
+
+      const tokenDoc = await Token.findOne({ user: signup.body.userId }).exec()
+      const confirmToken = tokenDoc.confirmToken
+
+      const confirmRes = await app.get(`/auth/confirm/${confirmToken}`)
+      expect(confirmRes.status).toBe(204)
+
+      const loginRes = await app.post('/auth/login').send({ email, password })
+      expect(loginRes.status).toBe(200)
+      expect(loginRes.body).toHaveProperty('accessToken')
     })
   })
 


### PR DESCRIPTION
## Implemented email confirmation functionality for user registration with proper error handling and email delivery via Gmail OAuth2.

#### Backend Implementation
- Added `confirmEmail` endpoint `GET /auth/confirm/:token`
- Implemented email confirmation logic in auth service
- Integrated existing token service for confirmation token handling
- Fixed email template path resolution in EmailTemplates initialization

#### Error Handling
- Added `EMAIL_ALREADY_CONFIRMED` error code
- Added `BAD_CONFIRM_TOKEN` error code
- Implemented proper error responses for different scenarios

#### Email Service
- Configured Gmail OAuth2 for email sending with refresh token
- Updated EmailTemplates to correctly resolve template paths

#### Testing
- Added integration tests for email confirmation flow
- Added tests for invalid token scenarios
- Added tests for already confirmed email
- Added tests for login blocking before confirmation
- All tests passing

#### Documentation
- Updated Swagger documentation with new endpoint

### Testing Instructions
1. Register new user via `POST /auth/signup`
2. Check email for confirmation link
3. Click confirmation link or use token with `GET /auth/confirm/:token`
4. Verify user can login after confirmation
5. Test error scenarios (invalid token, already confirmed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an email confirmation flow with a GET endpoint to confirm accounts via token; includes user-facing errors for invalid/expired tokens and already-confirmed emails.

* **Documentation**
  * API reference updated to include the confirmation endpoint and response codes.

* **Tests**
  * Added integration tests covering successful confirmation, invalid tokens, re-confirmation scenarios, and post-confirmation login (note: a duplicated test suite was introduced).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->